### PR TITLE
Fix missing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ idna==3.2
 numpy==1.21.1
 oscrypto==1.2.1
 Pillow==8.3.1
+pyasn1_modules==0.2.8
+pycountry==20.7.3
 pycparser==2.20
 pyzbar==0.1.8
 readerwriterlock==1.0.8


### PR DESCRIPTION
Add pyasn1_modules and pycountry.

Additional dependencies were required when installing with a clean pyenv. I have included the versions here which worked for me.