### PR TITLE
Support country name in unusual format

### DIFF
--- a/vacdec
+++ b/vacdec
@@ -291,7 +291,11 @@ def output_covid_cert_data(cert: dict, human_readable_output: bool, output_json_
         issuer = 'unknown'
         if 1 in cert:
             # This field is optional
-            issuer = countries.get(alpha_2=cert[1]).name
+            issuer_country = countries.get(alpha_2=cert[1])
+            if issuer_country is None:
+                issuer = cert[1]
+            else:
+                issuer = issuer_country.name
 
         # Health certificate Schema: https://github.com/ehn-dcc-development/ehn-dcc-schema/blob/release/1.3.0/DCC.schema.json
         # v = Vaccination


### PR DESCRIPTION
In France, the issuer is CNAM (Caisse Nationale d'Assurance Maladie) instead of FR. This makes the script crash around line 292.